### PR TITLE
add presenting view controller parameter

### DIFF
--- a/UPPlatformSDK/UPPlatformSDK/UPAuthViewController.h
+++ b/UPPlatformSDK/UPPlatformSDK/UPAuthViewController.h
@@ -25,7 +25,7 @@
 @interface UPAuthViewController : UINavigationController
 
 - (id)initWithURL:(NSURL *)url delegate:(id<UPAuthViewControllerDelegate>)delegate;
-- (void)show;
+- (void)presentWithViewController:(UIViewController*)presentingViewController;
 
 @end
 #endif

--- a/UPPlatformSDK/UPPlatformSDK/UPAuthViewController.m
+++ b/UPPlatformSDK/UPPlatformSDK/UPAuthViewController.m
@@ -80,9 +80,13 @@
     self.webView.backgroundColor = [UIColor whiteColor];
 }
 
-- (void)show
+- (void)presentWithViewController:(UIViewController*)presentingViewController;
 {
-    [self.rootViewController presentViewController:self animated:YES completion:^{
+    if (presentingViewController == nil) {
+        presentingViewController = self.rootViewController;
+    }
+    
+    [presentingViewController presentViewController:self animated:YES completion:^{
         [self.webView loadRequest:[NSURLRequest requestWithURL:self.authURL]];
     }];
 }

--- a/UPPlatformSDK/UPPlatformSDK/UPPlatform.h
+++ b/UPPlatformSDK/UPPlatformSDK/UPPlatform.h
@@ -178,6 +178,20 @@ typedef void(^UPPlatformRequestCompletion)(UPURLRequest *request, UPURLResponse 
  */
 - (void)startSessionWithClientID:(NSString *)clientID clientSecret:(NSString *)clientSecret authScope:(UPPlatformAuthScope)authScope redirectURI:(NSString *)redirectURI completion:(UPPlatformSessionCompletion)completion;
 
+/**
+ *  Starts a user's session.
+ *
+ *  This will present a UIWebView to perform the OAuth authentication flow, taking care of getting the access token for HTTP requests.
+ *
+ *  @param clientID     The client ID provided during application signup.
+ *  @param clientSecret The client secret provided during application signup.
+ *  @param authScope    Options to request specific auth scopes during authentication. Defaults to UPPlatformAuthScopeBasicRead.
+ *  @param redirectURI  An alternate redirect URI used during authentication. This is not common.
+ *  @param presentingViewController  View controller to present authentication view controller. Uses the window root view controller if nil.
+ *  @param completion   The session completion block.
+ */
+- (void)startSessionWithClientID:(NSString *)clientID clientSecret:(NSString *)clientSecret authScope:(UPPlatformAuthScope)authScope redirectURI:(NSString *)redirectURI presentingViewController:(UIViewController*)presentingViewController completion:(UPPlatformSessionCompletion)completion;
+
 #endif
 
 /**

--- a/UPPlatformSDK/UPPlatformSDK/UPPlatform.m
+++ b/UPPlatformSDK/UPPlatformSDK/UPPlatform.m
@@ -303,6 +303,11 @@ decisionListener:(id<WebPolicyDecisionListener>)listener
 
 - (void)startSessionWithClientID:(NSString *)clientID clientSecret:(NSString *)clientSecret authScope:(UPPlatformAuthScope)authScope redirectURI:(NSString *)redirectURI completion:(UPPlatformSessionCompletion)completion
 {
+    [self startSessionWithClientID:clientID clientSecret:clientSecret authScope:authScope redirectURI:redirectURI presentingViewController:nil completion:completion];
+}
+
+- (void)startSessionWithClientID:(NSString *)clientID clientSecret:(NSString *)clientSecret authScope:(UPPlatformAuthScope)authScope redirectURI:(NSString *)redirectURI presentingViewController:(UIViewController*)presentingViewController completion:(UPPlatformSessionCompletion)completion
+{
     self.sessionCompletion = completion;
     self.clientID = clientID;
     self.clientSecret = clientSecret;
@@ -328,7 +333,7 @@ decisionListener:(id<WebPolicyDecisionListener>)listener
     NSMutableString *authURLString = [NSMutableString stringWithFormat:@"%@/auth/oauth2/auth?response_type=code&client_id=%@&scope=%@&redirect_uri=%@", [UPPlatform basePlatformURL], self.clientID, [self stringFromAuthScope:authScope], redirectURI];
     
     self.authViewController = [[UPAuthViewController alloc] initWithURL:[NSURL URLWithString:authURLString] delegate:self];
-    [self.authViewController show];
+    [self.authViewController presentWithViewController:presentingViewController];
 }
 
 #endif


### PR DESCRIPTION
When authenticating, if there isn't a current session, the `UPPlatform` presents an `UPAuthViewController` on the key window's root view controller. This fails if another view is currently above the root view controller. (For example, if trying to authenticate from a modally presented view controller.) By allowing the caller to pass in a presenting view controller (and defaulting to the root view controller if nil) the UP SDK is more flexible and is easier to integrate with apps.

I've tried to make this change as minimal as possible. Yes, i had to add a crazy long method, but if you don't need to specify the presenting view controller, then the shorter methods are still available.

Let me know if you have any questions. I'd love to see this added.
