### PR TITLE
avoid exception: skip parse of nil data

### DIFF
--- a/UPPlatformSDK/UPPlatformSDK/UPPlatform.m
+++ b/UPPlatformSDK/UPPlatformSDK/UPPlatform.m
@@ -447,6 +447,11 @@ decisionListener:(id<WebPolicyDecisionListener>)listener
     
     [NSURLConnection sendAsynchronousRequest:request queue:[NSOperationQueue mainQueue] completionHandler:^(NSURLResponse *urlResponse, NSData *data, NSError *error) {
         
+        if (data == nil) { // no network
+            completion(request, nil, error);
+            return;
+        }
+        
         NSDictionary *jsonResponse = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
         
         if (self.enableNetworkLogging)


### PR DESCRIPTION
If there is no network then a call to `-[UPPlatform validateSessionWithCompletion]` eventually results in an exception when it tries to parse JSON from a nil value.