### PR TITLE
use barTintColor if available

### DIFF
--- a/UPPlatformSDK/UPPlatformSDK/UPAuthViewController.m
+++ b/UPPlatformSDK/UPPlatformSDK/UPAuthViewController.m
@@ -51,8 +51,13 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    
-    self.navigationBar.tintColor = [UIColor darkGrayColor];
+
+    UIColor *barColor = [UIColor darkGrayColor];
+    if ([self.navigationBar respondsToSelector:@selector(setBarTintColor:)]) {
+        self.navigationBar.barTintColor = barColor;
+    } else {
+        self.navigationBar.tintColor = barColor;
+    }
     self.navigationBar.translucent = NO;
     [self pushViewController:[[UIViewController alloc] init] animated:NO];
     


### PR DESCRIPTION
On iOS7 and 8, the navigation bar for the `UPAuthViewController` was white and you couldn't see the title or the "Cancel" button. Using `barTintColor` instead of `tintColor` fixes that.