### PR TITLE
Fix -dismissViewControllerAnimated:

### DIFF
--- a/UPPlatformSDK/UPPlatformSDK/UPAuthViewController.m
+++ b/UPPlatformSDK/UPPlatformSDK/UPAuthViewController.m
@@ -101,7 +101,7 @@
     if (self.isHiding) return;
     self.isHiding = YES;
     
-    [self.rootViewController dismissViewControllerAnimated:YES completion:^{
+    [self dismissViewControllerAnimated:YES completion:^{
         if (completion) completion();
     }];
 }


### PR DESCRIPTION
Fix -dismissViewControllerAnimated: should not be called on self.rootViewController. It should be on self instead. So it correctly dismisses when presented from, for example, a modal view controller. Dismissing on rootViewController (which holds window's root view controller) will incorrectly dismiss BOTH UPAuthViewController and the modal view controller it is presented on.
